### PR TITLE
corrected capability isVMProductDCConstrained from false to true, as

### DIFF
--- a/src/main/java/org/dasein/cloud/google/capabilities/GCEInstanceCapabilities.java
+++ b/src/main/java/org/dasein/cloud/google/capabilities/GCEInstanceCapabilities.java
@@ -310,6 +310,6 @@ public class GCEInstanceCapabilities extends AbstractCapabilities<Google> implem
 
     @Override
     public boolean isVMProductDCConstrained() throws InternalException, CloudException {
-        return false;
+        return true; // 32-core machine types are available only in Ivy Bridge and Haswell zones.
     }
 }

--- a/src/main/java/org/dasein/cloud/google/network/IPAddressSupport.java
+++ b/src/main/java/org/dasein/cloud/google/network/IPAddressSupport.java
@@ -89,7 +89,7 @@ public class IPAddressSupport extends AbstractIpAddressSupport<Google> {
         try{
             Compute gce = getProvider().getGoogleCompute();
             IpAddress ipAddress = getIpAddress(addressId);
-
+            serverId = serverId.replaceAll("_[0-9]+$", "");  // Cope with vmName_vmId
             VirtualMachine vm = getProvider().getComputeServices().getVirtualMachineSupport().getVirtualMachine(serverId);
 
             AccessConfig accessConfig = new AccessConfig();


### PR DESCRIPTION
some flavors are only available in certain data centers.
