### PR TITLE
VM object now populated with the username of the account that ssh keys

### DIFF
--- a/src/main/java/org/dasein/cloud/google/compute/server/ServerSupport.java
+++ b/src/main/java/org/dasein/cloud/google/compute/server/ServerSupport.java
@@ -994,6 +994,13 @@ public class ServerSupport extends AbstractVMSupport<Google> {
                 }
             }
         }
+
+        for (Items metadataItem : instance.getMetadata().getItems()) {
+            if (metadataItem.getKey().equals("sshKeys")) {
+                vm.setRootUser(metadataItem.getValue().replaceAll(":.*", ""));
+            }
+        }
+
         vm.setPublicAddresses(publicAddresses.toArray(new RawAddress[publicAddresses.size()]));
         vm.setPrivateAddresses(privateAddresses.toArray(new RawAddress[privateAddresses.size()]));
         vm.setProviderAssignedIpAddressId(providerAssignedIpAddressId);


### PR DESCRIPTION
enable login to using setRootUser.  this account can sudo su, so
technically a root account.
